### PR TITLE
`<=` and `>=` operators are inverted

### DIFF
--- a/src/semver.nim
+++ b/src/semver.nim
@@ -229,8 +229,8 @@ func `<`*(v1: Version, v2: Version): bool =
 
 func `<=`*(v1: Version, v2: Version): bool =
   ## Check whether v1 is less than or equal to v2.
-  not isGreaterThan(v2, v1)
+  not isGreaterThan(v1, v2)
 
 func `>=`*(v1: Version, v2: Version): bool =
   ## Check whether v1 is greater than or equal to v2.
-  not isLessThan(v2, v1)
+  not isLessThan(v1, v2)

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -149,6 +149,26 @@ suite "semver tests":
     let ver2 = newVersion(1, 2, 6, "alpha", "001")
     check ver1 <= ver2
 
+  test "Check whether naive version 1 is less than or equal to naive version 2 with operator":
+    let ver1 = newVersion(1, 0, 0)
+    let ver2 = newVersion(2, 0, 0)
+    check ver1 <= ver2
+
+  test "Check whether naive version 1 is greater than or equal to naive version 2 with operator":
+    let ver1 = newVersion(1, 0, 0)
+    let ver2 = newVersion(2, 0, 0)
+    check ver2 >= ver1
+
+  test "Check whether complex version 1 is less than or equal to complex version 2 with operator":
+    let ver1 = newVersion(1, 0, 0, "alpha", "001")
+    let ver2 = newVersion(2, 0, 0, "alpha", "001")
+    check ver1 <= ver2
+
+  test "Check whether complex version 1 is greater than or equal to complex version 2 with operator":
+    let ver1 = newVersion(1, 0, 0, "alpha", "001")
+    let ver2 = newVersion(2, 0, 0, "alpha", "001")
+    check ver2 >= ver1
+
   test "semver.org example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.":
     let ver1 = newVersion(1, 0, 0)
     let ver2 = newVersion(1, 0, 0, "alpha")


### PR DESCRIPTION
This caught me by surprise and actually broke one of my tools until I hotfixed it by switching to the lower-level `isGreaterThan` and `isLessThan` procs.

I assume this is the proper fix.


Reproduction of the bug with the current release version:
```nim
let v1 = newVersion(1, 0, 0)
let v2 = newVersion(2, 0, 0)

echo v1 >= v2 # result: true | should be: false
echo v1 <= v2 # result: false | should be: true
```

Using this patch, the results are inverted as they should be.